### PR TITLE
[Task-28] As a user, I can use refresh token to extend access token expiration date

### DIFF
--- a/cypress/fixtures/refreshTokenResponse/error_response.json
+++ b/cypress/fixtures/refreshTokenResponse/error_response.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+     {
+        "source": "Doorkeeper::OAuth::Error",
+        "detail": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+        "code": "invalid_grant"
+     }
+  ]
+}

--- a/cypress/fixtures/refreshTokenResponse/valid_response.json
+++ b/cypress/fixtures/refreshTokenResponse/valid_response.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+     "id": 1,
+     "type": "token",
+     "attributes": {
+        "access_token": "test-access-token",
+        "token_type": "Bearer",
+        "expires_in": 99,
+        "refresh_token": "test-refresh-token",
+        "created_at": 999
+     }
+  }
+}

--- a/cypress/fixtures/surveyListResponse/unauthorized_response.json
+++ b/cypress/fixtures/surveyListResponse/unauthorized_response.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "message": "The access token expired",
+      "extensions": {
+        "code": "invalid_token",
+        "state": "unauthorized"
+      }
+    }
+  ]
+}

--- a/cypress/integration/RefreshToken/refreshToken.spec.ts
+++ b/cypress/integration/RefreshToken/refreshToken.spec.ts
@@ -2,28 +2,30 @@ import { formSelectors } from './selectors'
 
 describe('Refresh Token', () => {
   context('given expired access token', () => {
-    // context('given valid refresh token', () => {
-    //   it('redirects back to survey list page', () => {
-    //     cy.mockSignInResponse(200, 'signInResponse/valid_response.json')
-    //     cy.mockSurveyListResponse(401, 'surveyListResponse/unauthorized_response.json').as('call1')
-    //     cy.mockRefreshTokenResponse(200, 'refreshTokenResponse/valid_response.json')
+    context('given valid refresh token', () => {
+      it('redirects back to home page', () => {
+        cy.mockSignInResponse(200, 'signInResponse/valid_response.json')
+        cy.mockSurveyListResponse(401, 'surveyListResponse/unauthorized_response.json')
+        cy.mockRefreshTokenResponse(200, 'refreshTokenResponse/valid_response.json')
+        
+        cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
+        cy.findByTestId(formSelectors.signInButton).click()
+        
+        cy.url().should('not.include', '/sign-in')
+        cy.url().should('include', '/')
 
-    //     cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
-    //     cy.findByTestId(formSelectors.signInButton).click()
-
-
-    //     // cy.url().should('include', '/')
-    //   })
-    // })
+        cy.mockSurveyListResponse(200, 'surveyListResponse/valid_response.json')
+      })
+    })
 
     context('given invalid refresh token', () => {
       it('redirects back to sign in page', () => {
         cy.mockSignInResponse(200, 'signInResponse/valid_response.json')
-        cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
-        cy.findByTestId(formSelectors.signInButton).click()
-
         cy.mockSurveyListResponse(401, 'surveyListResponse/unauthorized_response.json')
         cy.mockRefreshTokenResponse(400, 'refreshTokenResponse/error_response.json')
+
+        cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
+        cy.findByTestId(formSelectors.signInButton).click()
 
         cy.url().should('include', '/sign-in')
       })

--- a/cypress/integration/RefreshToken/refreshToken.spec.ts
+++ b/cypress/integration/RefreshToken/refreshToken.spec.ts
@@ -1,0 +1,32 @@
+import { formSelectors } from './selectors'
+
+describe('Refresh Token', () => {
+  context('given expired access token', () => {
+    // context('given valid refresh token', () => {
+    //   it('redirects back to survey list page', () => {
+    //     cy.mockSignInResponse(200, 'signInResponse/valid_response.json')
+    //     cy.mockSurveyListResponse(401, 'surveyListResponse/unauthorized_response.json').as('call1')
+    //     cy.mockRefreshTokenResponse(200, 'refreshTokenResponse/valid_response.json')
+
+    //     cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
+    //     cy.findByTestId(formSelectors.signInButton).click()
+
+
+    //     // cy.url().should('include', '/')
+    //   })
+    // })
+
+    context('given invalid refresh token', () => {
+      it('redirects back to sign in page', () => {
+        cy.mockSignInResponse(200, 'signInResponse/valid_response.json')
+        cy.signIn(Cypress.env('CYPRESS_VALID_EMAIL'), Cypress.env('CYPRESS_VALID_PASSWORD'))
+        cy.findByTestId(formSelectors.signInButton).click()
+
+        cy.mockSurveyListResponse(401, 'surveyListResponse/unauthorized_response.json')
+        cy.mockRefreshTokenResponse(400, 'refreshTokenResponse/error_response.json')
+
+        cy.url().should('include', '/sign-in')
+      })
+    })
+  })
+})

--- a/cypress/integration/RefreshToken/selectors.ts
+++ b/cypress/integration/RefreshToken/selectors.ts
@@ -1,0 +1,6 @@
+const formSelectors = {
+  signInButton: 'formButton',
+  userAvatar: 'surveyHeaderUserImage'
+}
+
+export { formSelectors }

--- a/cypress/integration/RefreshToken/selectors.ts
+++ b/cypress/integration/RefreshToken/selectors.ts
@@ -1,6 +1,5 @@
 const formSelectors = {
   signInButton: 'formButton',
-  userAvatar: 'surveyHeaderUserImage'
 }
 
 export { formSelectors }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -3,4 +3,5 @@
 import '@testing-library/cypress/add-commands'
 import './commands/signIn'
 import './commands/forgotPassword'
+import './commands/refreshToken'
 import './commands/surveyList'

--- a/cypress/support/commands/refreshToken.ts
+++ b/cypress/support/commands/refreshToken.ts
@@ -1,0 +1,10 @@
+const mockRefreshTokenResponse = (statusCode: number, fixture: string): void => {
+  cy.intercept('POST', '**/api/v1/oauth/token', (req) => {
+    req.reply({
+      statusCode: statusCode,
+      fixture: fixture
+    })
+  })
+}
+
+Cypress.Commands.add('mockRefreshTokenResponse', mockRefreshTokenResponse)

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -7,5 +7,7 @@ declare namespace Cypress {
     forgotPassword(email: string): Cypress.Chainable<void>
 
     mockSurveyListResponse(statusCode: number, fixture: string): Cypress.Chainable<void>
+
+    mockRefreshTokenResponse(statusCode: number, fixture: string): Cypress.Chainable<void>
   }
 }

--- a/src/adapters/auth.ts
+++ b/src/adapters/auth.ts
@@ -4,6 +4,7 @@ import { AxiosResponse } from 'axios'
 
 import { postWithJsonBodyHeaders } from 'adapters/headers'
 import requestManager from 'lib/requestManager'
+import LocalStorage from 'services/localStorage'
 
 class AuthAdapter {
   static DEFAULT_PAYLOAD = {
@@ -50,7 +51,7 @@ class AuthAdapter {
       },
       data: {
         grant_type: 'refresh_token',
-        refresh_token: localStorage.getItem('refresh_token'),
+        refresh_token: LocalStorage.get('refresh_token'),
         ...AuthAdapter.DEFAULT_PAYLOAD
       }
     }

--- a/src/adapters/auth.ts
+++ b/src/adapters/auth.ts
@@ -42,6 +42,21 @@ class AuthAdapter {
 
     return requestManager('POST', `${process.env.REACT_APP_NIMBLE_SURVEY_BASE_URL}/api/v1/passwords`, requestOptions)
   }
+
+  static refreshAccessToken = (): Promise<AxiosResponse> => {
+    const requestOptions = {
+      headers: {
+        ...postWithJsonBodyHeaders
+      },
+      data: {
+        grant_type: 'refresh_token',
+        refresh_token: localStorage.getItem('refresh_token'),
+        ...AuthAdapter.DEFAULT_PAYLOAD
+      }
+    }
+
+    return requestManager('POST', `${process.env.REACT_APP_NIMBLE_SURVEY_BASE_URL}/api/v1/oauth/token`, requestOptions)
+  }
 }
 
 export default AuthAdapter

--- a/src/adapters/survey.ts
+++ b/src/adapters/survey.ts
@@ -12,6 +12,7 @@ import {
 import { setContext } from '@apollo/client/link/context'
 import { onError } from '@apollo/client/link/error'
 
+import LocalStorage from 'services/localStorage'
 import refreshAccessToken from 'services/refreshToken'
 
 class SurveyAdapter {
@@ -21,7 +22,7 @@ class SurveyAdapter {
     })
 
     const authLink = setContext((_, { headers }) => {
-      const token = localStorage.getItem('access_token')
+      const token = LocalStorage.get('access_token')
       return {
         headers: {
           ...headers,

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -2,6 +2,7 @@ import React, { createContext, Dispatch, useReducer, useEffect } from 'react'
 
 import * as Constants from 'constants/auth'
 import AuthReducer from 'reducers/auth'
+import LocalStorage from 'services/localStorage'
 
 type AuthProvider = {
   children: JSX.Element
@@ -28,7 +29,7 @@ const AuthProvider = ({ children }: AuthProvider): JSX.Element => {
   const [state, dispatch] = useReducer(AuthReducer, initialState)
 
   useEffect(() => {
-    const refreshToken = localStorage.getItem('refresh_token')
+    const refreshToken = LocalStorage.get('refresh_token')
     if (!state.isAuthenticated && refreshToken) {
       dispatch({ type: Constants.REFRESH })
     }

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -1,5 +1,6 @@
 import * as Constants from 'constants/auth'
 import { AuthState } from 'contexts/auth'
+import LocalStorage from 'services/localStorage'
 
 /* eslint-disable camelcase */
 type AuthTypePayload = {
@@ -22,17 +23,13 @@ const AuthReducer = (state: AuthState, action: ActionType): AuthState => {
       if (!data) {
         return state
       }
-      localStorage.setItem('access_token', data.access_token)
-      localStorage.setItem('refresh_token', data.refresh_token)
-      localStorage.setItem('token_type', data.token_type)
+
+      LocalStorage.setToken(data.access_token, data.refresh_token, data.token_type)
 
       return { ...state, isAuthenticated: true }
     }
     case Constants.LOGOUT: {
-      localStorage.removeItem('access_token')
-      localStorage.removeItem('refresh_token')
-      localStorage.removeItem('token_type')
-      localStorage.removeItem('lastVisitedRoute')
+      LocalStorage.clear()
 
       return { ...state, isAuthenticated: false }
     }

--- a/src/routes/routeAuthentication.tsx
+++ b/src/routes/routeAuthentication.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import { Route, Redirect } from 'react-router-dom'
 
 import { AuthContext } from 'contexts/auth'
+import LocalStorage from 'services/localStorage'
 
 type RouteAuthentication = {
   component: () => JSX.Element
@@ -11,7 +12,7 @@ type RouteAuthentication = {
 
 const PrivateRoute = ({ ...props }: RouteAuthentication): JSX.Element => {
   const { state } = useContext(AuthContext)
-  localStorage.setItem('lastVisitedRoute', window.location.pathname)
+  LocalStorage.set('lastVisitedRoute', window.location.pathname)
 
   if (state.isAuthenticated) {
     return <Route {...props} />
@@ -21,7 +22,7 @@ const PrivateRoute = ({ ...props }: RouteAuthentication): JSX.Element => {
 
 const PublicRoute = ({ ...props }: RouteAuthentication): JSX.Element => {
   const { state } = useContext(AuthContext)
-  const lastVisitedRoute = localStorage.getItem('lastVisitedRoute') || '/'
+  const lastVisitedRoute = LocalStorage.get('lastVisitedRoute') || '/'
 
   if (!state.isAuthenticated) {
     return <Route {...props} />

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -4,14 +4,15 @@ import { FetchSurveyList } from 'adapters/survey'
 import LazyLoader from 'components/LazyLoader'
 import { SurveyBackgroundProvider } from 'contexts/surveyBackground'
 import Survey from 'screens/Home/survey'
+import refreshAccessToken from 'services/refreshToken'
 
 const Home = (): JSX.Element => {
   const { data, loading, error } = FetchSurveyList()
 
   if (loading) return <LazyLoader />
   if (error?.networkError?.message.includes('401')) {
-    // TODO: Redirect to home page and clear local storage (this still not working because of REFRESH action bug)
-    return <p>Unauthorized</p>
+    refreshAccessToken()
+    return <LazyLoader />
   }
   if (error) {
     // TODO: Create something went wrong screen

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -4,14 +4,12 @@ import { FetchSurveyList } from 'adapters/survey'
 import LazyLoader from 'components/LazyLoader'
 import { SurveyBackgroundProvider } from 'contexts/surveyBackground'
 import Survey from 'screens/Home/survey'
-import refreshAccessToken from 'services/refreshToken'
 
 const Home = (): JSX.Element => {
   const { data, loading, error } = FetchSurveyList()
 
   if (loading) return <LazyLoader />
   if (error?.networkError?.message.includes('401')) {
-    refreshAccessToken()
     return <LazyLoader />
   }
   if (error) {

--- a/src/screens/SurveyDetail/index.tsx
+++ b/src/screens/SurveyDetail/index.tsx
@@ -5,6 +5,7 @@ import { FetchSurveyDetail } from 'adapters/survey'
 import BackButton from 'components/BackButton'
 import Background from 'components/Background'
 import LazyLoader from 'components/LazyLoader'
+import refreshAccessToken from 'services/refreshToken'
 
 type SurveyDetailParams = {
   surveyID: string
@@ -16,8 +17,8 @@ const SurveyDetail = (): JSX.Element => {
   const { data, loading, error } = FetchSurveyDetail(surveyID)
   if (loading) return <LazyLoader />
   if (error?.networkError?.message.includes('401')) {
-    // TODO: Redirect to home page and clear local storage (this still not working because of REFRESH action bug)
-    return <p>Unauthorized</p>
+    refreshAccessToken()
+    return <LazyLoader />
   }
   if (error) {
     // TODO: Create something went wrong screen

--- a/src/screens/SurveyDetail/index.tsx
+++ b/src/screens/SurveyDetail/index.tsx
@@ -5,7 +5,6 @@ import { FetchSurveyDetail } from 'adapters/survey'
 import BackButton from 'components/BackButton'
 import Background from 'components/Background'
 import LazyLoader from 'components/LazyLoader'
-import refreshAccessToken from 'services/refreshToken'
 
 type SurveyDetailParams = {
   surveyID: string
@@ -17,7 +16,6 @@ const SurveyDetail = (): JSX.Element => {
   const { data, loading, error } = FetchSurveyDetail(surveyID)
   if (loading) return <LazyLoader />
   if (error?.networkError?.message.includes('401')) {
-    refreshAccessToken()
     return <LazyLoader />
   }
   if (error) {

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -1,0 +1,24 @@
+class LocalStorage {
+  static get(key: string): string | null {
+    return localStorage.getItem(key)
+  }
+
+  static set(key: string, value: string) {
+    localStorage.setItem(key, value)
+  }
+
+  static setToken = (accessToken: string, refreshToken: string, tokenType: string) => {
+    localStorage.setItem('access_token', accessToken)
+    localStorage.setItem('refresh_token', refreshToken)
+    localStorage.setItem('token_type', tokenType)
+  }
+
+  static clear = () => {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    localStorage.removeItem('token_type')
+    localStorage.removeItem('lastVisitedRoute')
+  }
+}
+
+export default LocalStorage

--- a/src/services/localStorage.ts
+++ b/src/services/localStorage.ts
@@ -1,19 +1,19 @@
 class LocalStorage {
-  static get(key: string): string | null {
+  static get = (key: string): string | null => {
     return localStorage.getItem(key)
   }
 
-  static set(key: string, value: string) {
+  static set = (key: string, value: string): void => {
     localStorage.setItem(key, value)
   }
 
-  static setToken = (accessToken: string, refreshToken: string, tokenType: string) => {
+  static setToken = (accessToken: string, refreshToken: string, tokenType: string): void => {
     localStorage.setItem('access_token', accessToken)
     localStorage.setItem('refresh_token', refreshToken)
     localStorage.setItem('token_type', tokenType)
   }
 
-  static clear = () => {
+  static clear = (): void => {
     localStorage.removeItem('access_token')
     localStorage.removeItem('refresh_token')
     localStorage.removeItem('token_type')

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios'
 
 import AuthAdapter from 'adapters/auth'
+import LocalStorage from 'services/localStorage'
 
 const refreshAccessToken = async () => {
   await AuthAdapter.refreshAccessToken()
@@ -8,19 +9,14 @@ const refreshAccessToken = async () => {
       if (response.status === 200) {
         /* eslint-disable camelcase */
         const { access_token, refresh_token, token_type } = response.data.data.attributes
-        localStorage.setItem('access_token', access_token)
-        localStorage.setItem('refresh_token', refresh_token)
-        localStorage.setItem('token_type', token_type)
+        LocalStorage.setToken(access_token, refresh_token, token_type)
       }
     })
     .catch(function () {
-      localStorage.removeItem('access_token')
-      localStorage.removeItem('refresh_token')
-      localStorage.removeItem('token_type')
-      localStorage.removeItem('lastVisitedRoute')
+      LocalStorage.clear()
     })
 
-  window.location.href = localStorage.getItem('lastVisitedRoute') || '/'
+  window.location.href = LocalStorage.get('lastVisitedRoute') || '/'
 }
 
 export default refreshAccessToken

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from 'axios'
 import AuthAdapter from 'adapters/auth'
 import LocalStorage from 'services/localStorage'
 
-const refreshAccessToken = async () => {
+const refreshAccessToken = async (): Promise<void> => {
   await AuthAdapter.refreshAccessToken()
     .then(function (response: AxiosResponse) {
       if (response.status === 200) {

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -1,0 +1,26 @@
+import { AxiosResponse } from 'axios'
+
+import AuthAdapter from 'adapters/auth'
+
+const refreshAccessToken = async () => {
+  await AuthAdapter.refreshAccessToken()
+    .then(function (response: AxiosResponse) {
+      if (response.status === 200) {
+        /* eslint-disable camelcase */
+        const { access_token, refresh_token, token_type } = response.data.data.attributes
+        localStorage.setItem('access_token', access_token)
+        localStorage.setItem('refresh_token', refresh_token)
+        localStorage.setItem('token_type', token_type)
+      }
+    })
+    .catch(function () {
+      localStorage.removeItem('access_token')
+      localStorage.removeItem('refresh_token')
+      localStorage.removeItem('token_type')
+      localStorage.removeItem('lastVisitedRoute')
+    })
+
+  window.location.href = localStorage.getItem('lastVisitedRoute') || '/'
+}
+
+export default refreshAccessToken

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -10,13 +10,13 @@ const refreshAccessToken = async () => {
         /* eslint-disable camelcase */
         const { access_token, refresh_token, token_type } = response.data.data.attributes
         LocalStorage.setToken(access_token, refresh_token, token_type)
+        window.location.href = LocalStorage.get('lastVisitedRoute') || '/'
       }
     })
     .catch(function () {
       LocalStorage.clear()
+      window.location.href = '/sign-in'
     })
-
-  window.location.href = LocalStorage.get('lastVisitedRoute') || '/'
 }
 
 export default refreshAccessToken

--- a/src/services/refreshToken.ts
+++ b/src/services/refreshToken.ts
@@ -5,7 +5,7 @@ import LocalStorage from 'services/localStorage'
 
 const refreshAccessToken = async (): Promise<void> => {
   await AuthAdapter.refreshAccessToken()
-    .then(function (response: AxiosResponse) {
+    .then((response: AxiosResponse) => {
       if (response.status === 200) {
         /* eslint-disable camelcase */
         const { access_token, refresh_token, token_type } = response.data.data.attributes
@@ -13,7 +13,7 @@ const refreshAccessToken = async (): Promise<void> => {
         window.location.href = LocalStorage.get('lastVisitedRoute') || '/'
       }
     })
-    .catch(function () {
+    .catch(() => {
       LocalStorage.clear()
       window.location.href = '/sign-in'
     })

--- a/src/tests/fixtures/oauthTokenResponse.json
+++ b/src/tests/fixtures/oauthTokenResponse.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "data": {
+      "attributes": {
+        "id": 1,
+        "type": "token",
+        "attributes": {
+           "access_token": "test-access-token",
+           "token_type": "Bearer",
+           "expires_in": 99,
+           "refresh_token": "test-refresh-token",
+           "created_at": 999
+        }
+      }
+    }
+  }
+}

--- a/src/tests/screens/Home/index.test.tsx
+++ b/src/tests/screens/Home/index.test.tsx
@@ -27,10 +27,10 @@ describe('given Home page is mounted', () => {
   })
 
   describe('given unautorized response', () => {
-    it('renders unauthorized content', async () => {
+    it('renders lazy loader', async () => {
       const mocks = { ...homeErrorResponse(graphQLErrorType.unauthorized) }
 
-      const { getByText } = render(
+      const { getByTestId } = render(
         <BrowserRouter>
           <MockedProvider mocks={[mocks]} addTypename={false}>
             <Home />
@@ -40,7 +40,7 @@ describe('given Home page is mounted', () => {
 
       await waitFor(() => new Promise((res) => setTimeout(res, 0)))
 
-      const result = getByText('Unauthorized')
+      const result = getByTestId('lazyLoader')
       expect(result).toBeInTheDocument()
     })
   })

--- a/src/tests/screens/SurveyDetail/index.test.tsx
+++ b/src/tests/screens/SurveyDetail/index.test.tsx
@@ -32,11 +32,11 @@ describe('given SurveyDetail page is mounted', () => {
   })
 
   describe('given unauthorized response', () => {
-    it('renders unauthorized content', async () => {
+    it('renders lazy loader', async () => {
       const surveyID = '1'
       const mocks = { ...surveyDetailErrorResponse(graphQLErrorType.unauthorized, surveyID) }
 
-      const { getByText } = render(
+      const { getByTestId } = render(
         <MemoryRouter initialEntries={[`survey/${surveyID}`]}>
           <Route path="survey/:surveyID">
             <MockedProvider mocks={[mocks]} addTypename={false}>
@@ -48,7 +48,7 @@ describe('given SurveyDetail page is mounted', () => {
 
       await waitFor(() => new Promise((res) => setTimeout(res, 0)))
 
-      const result = getByText('Unauthorized')
+      const result = getByTestId('lazyLoader')
       expect(result).toBeInTheDocument()
     })
   })

--- a/src/tests/services/localStorage.test.ts
+++ b/src/tests/services/localStorage.test.ts
@@ -9,19 +9,19 @@ describe('LocalStorage service', () => {
     describe('given valid key pair', () => {
       it('returns correct value', () => {
         localStorage.setItem('test-key', 'test-value')
-  
+
         const result = LocalStorage.get('test-key')
-  
+
         expect(result).toEqual('test-value')
       })
     })
-  
+
     describe('given invalid key pair', () => {
       it('returns null', () => {
         localStorage.setItem('test-key', 'test-value')
-  
+
         const result = LocalStorage.get('invalid-key')
-  
+
         expect(result).toBeNull()
       })
     })
@@ -68,11 +68,11 @@ describe('LocalStorage service', () => {
       LocalStorage.setToken('test-access', 'test-refresh', 'test-token-type')
       LocalStorage.set('lastVisitedRoute', 'test-route')
 
-      expect(localStorage.length).toBe(4)
+      expect(localStorage).toHaveLength(4)
 
       LocalStorage.clear()
 
-      expect(localStorage.length).toBe(0)
+      expect(localStorage).toHaveLength(0)
     })
   })
 })

--- a/src/tests/services/localStorage.test.ts
+++ b/src/tests/services/localStorage.test.ts
@@ -1,0 +1,78 @@
+import LocalStorage from 'services/localStorage'
+
+describe('LocalStorage service', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('get', () => {
+    describe('given valid key pair', () => {
+      it('returns correct value', () => {
+        localStorage.setItem('test-key', 'test-value')
+  
+        const result = LocalStorage.get('test-key')
+  
+        expect(result).toEqual('test-value')
+      })
+    })
+  
+    describe('given invalid key pair', () => {
+      it('returns null', () => {
+        localStorage.setItem('test-key', 'test-value')
+  
+        const result = LocalStorage.get('invalid-key')
+  
+        expect(result).toBeNull()
+      })
+    })
+  })
+
+  describe('set', () => {
+    it('sets correct value', () => {
+      LocalStorage.set('test-key', 'test-value')
+
+      const result = localStorage.getItem('test-key')
+
+      expect(result).toEqual('test-value')
+    })
+  })
+
+  describe('setToken', () => {
+    it('sets correct access token', () => {
+      LocalStorage.setToken('test-access', 'test-refresh', 'test-token-type')
+
+      const result = localStorage.getItem('access_token')
+
+      expect(result).toEqual('test-access')
+    })
+
+    it('sets correct refresh token', () => {
+      LocalStorage.setToken('test-access', 'test-refresh', 'test-token-type')
+
+      const result = localStorage.getItem('refresh_token')
+
+      expect(result).toEqual('test-refresh')
+    })
+
+    it('sets correct token type', () => {
+      LocalStorage.setToken('test-access', 'test-refresh', 'test-token-type')
+
+      const result = localStorage.getItem('token_type')
+
+      expect(result).toEqual('test-token-type')
+    })
+  })
+
+  describe('clear', () => {
+    it('removes app related value from local storage', () => {
+      LocalStorage.setToken('test-access', 'test-refresh', 'test-token-type')
+      LocalStorage.set('lastVisitedRoute', 'test-route')
+
+      expect(localStorage.length).toBe(4)
+
+      LocalStorage.clear()
+
+      expect(localStorage.length).toBe(0)
+    })
+  })
+})

--- a/src/tests/services/refreshToken.test.ts
+++ b/src/tests/services/refreshToken.test.ts
@@ -3,6 +3,7 @@
 import axios, { AxiosResponse } from 'axios'
 
 import refreshAccessToken from 'services/refreshToken'
+import oauthTokenResponse from 'tests/fixtures/oauthTokenResponse.json'
 
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
@@ -51,21 +52,7 @@ describe('refreshToken service', () => {
 
     it('redirects to home page', async () => {
       const mockedResponse: AxiosResponse = {
-        data: {
-          data: {
-            attributes: {
-              id: 1,
-              type: 'token',
-              attributes: {
-                 access_token: 'test-access-token',
-                 token_type: 'Bearer',
-                 expires_in: 99,
-                 refresh_token: 'test-refresh-token',
-                 created_at: 999
-              }
-            }
-          }
-        },
+        ...oauthTokenResponse,
         status: 200,
         statusText: 'Ok',
         headers: {},
@@ -82,21 +69,7 @@ describe('refreshToken service', () => {
       it('redirects to last visited path', async () => {
         localStorage.setItem('lastVisitedRoute', '/test-path')
         const mockedResponse: AxiosResponse = {
-          data: {
-            data: {
-              attributes: {
-                id: 1,
-                type: 'token',
-                attributes: {
-                   access_token: 'test-access-token',
-                   token_type: 'Bearer',
-                   expires_in: 99,
-                   refresh_token: 'test-refresh-token',
-                   created_at: 999
-                }
-              }
-            }
-          },
+          ...oauthTokenResponse,
           status: 200,
           statusText: 'Ok',
           headers: {},

--- a/src/tests/services/refreshToken.test.ts
+++ b/src/tests/services/refreshToken.test.ts
@@ -1,0 +1,145 @@
+/* eslint-disable */
+
+import axios, { AxiosResponse } from 'axios'
+
+import refreshAccessToken from 'services/refreshToken'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('refreshToken service', () => {
+  const mockResponse = jest.fn()
+  Object.defineProperty(window, 'location', {
+    value: {
+      href: mockResponse
+    }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('given valid refresh token response', () => {
+    it('stores data to local storage', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          data: {
+            attributes: {
+              id: 1,
+              type: 'token',
+              attributes: {
+                 access_token: 'test-access-token',
+                 token_type: 'Bearer',
+                 expires_in: 99,
+                 refresh_token: 'test-refresh-token',
+                 created_at: 999
+              }
+            }
+          }
+        },
+        status: 200,
+        statusText: 'Ok',
+        headers: {},
+        config: {}
+      }
+      mockedAxios.request.mockResolvedValue(mockedResponse)
+  
+      await refreshAccessToken()
+  
+      expect(Object.keys(localStorage)).toEqual(['access_token', 'refresh_token', 'token_type'])
+    })
+
+    it('redirects to home page', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: {
+          data: {
+            attributes: {
+              id: 1,
+              type: 'token',
+              attributes: {
+                 access_token: 'test-access-token',
+                 token_type: 'Bearer',
+                 expires_in: 99,
+                 refresh_token: 'test-refresh-token',
+                 created_at: 999
+              }
+            }
+          }
+        },
+        status: 200,
+        statusText: 'Ok',
+        headers: {},
+        config: {}
+      }
+      mockedAxios.request.mockResolvedValue(mockedResponse)
+  
+      await refreshAccessToken()
+  
+      expect(window.location.href).toBe('/')
+    })
+
+    describe ('given last visited route', () => {
+      it('redirects to last visited path', async () => {
+        localStorage.setItem('lastVisitedRoute', '/test-path')
+        const mockedResponse: AxiosResponse = {
+          data: {
+            data: {
+              attributes: {
+                id: 1,
+                type: 'token',
+                attributes: {
+                   access_token: 'test-access-token',
+                   token_type: 'Bearer',
+                   expires_in: 99,
+                   refresh_token: 'test-refresh-token',
+                   created_at: 999
+                }
+              }
+            }
+          },
+          status: 200,
+          statusText: 'Ok',
+          headers: {},
+          config: {}
+        }
+        mockedAxios.request.mockResolvedValue(mockedResponse)
+    
+        await refreshAccessToken()
+    
+        expect(window.location.href).toBe('/test-path')
+      })
+    })
+  })
+
+  describe('given invalid refresh token response', () => {
+    it('does NOT store data to local storage', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: null,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {}
+      }
+      mockedAxios.request.mockRejectedValue(mockedResponse)
+  
+      await refreshAccessToken()
+  
+      expect(Object.keys(localStorage)).toEqual([])
+    })
+
+    it('redirects to sign in page', async () => {
+      const mockedResponse: AxiosResponse = {
+        data: null,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {}
+      }
+      mockedAxios.request.mockRejectedValue(mockedResponse)
+  
+      await refreshAccessToken()
+  
+      expect(window.location.href).toBe('/sign-in')
+    })
+  })
+})


### PR DESCRIPTION
#49 

## What happened 👀

- Extend access token expiration date using refresh token when got 401 when fetching data from private endpoint.
- Add local storage service
- Add refresh token service
- Add unit test
- Add UI test
 
## Insight 📝

N/A
 
## Proof Of Work 📹

- Extend access token expiration
![JUK81BZTL6](https://user-images.githubusercontent.com/29707647/125061716-d15c2700-e0d7-11eb-9306-4c0210aa67ae.gif)

- oauth endpoint return status error response
![Xz7FzI9mey](https://user-images.githubusercontent.com/29707647/125061743-da4cf880-e0d7-11eb-801d-9e151e0e3bbe.gif)
